### PR TITLE
Updated setAutomaticActivation SC function arguments to true/false instead of yes/no

### DIFF
--- a/react-delegationdashboard/src/components/Overview/Cards/AutomaticActivationAction/AutomaticActivationModal.tsx
+++ b/react-delegationdashboard/src/components/Overview/Cards/AutomaticActivationAction/AutomaticActivationModal.tsx
@@ -20,7 +20,7 @@ const AutomaticActivationModal = ({
 }: AutomaticActivationModalType) => {
   const { delegation } = useDelegation();
   const handleAutomaticActivation = () => {
-    let activation = Buffer.from(value === 'true' ? 'no' : 'yes').toString('hex');
+    let activation = Buffer.from(value === 'true' ? 'false' : 'true').toString('hex');
     delegation.sendTransaction('0', 'setAutomaticActivation', activation).then();
   };
 


### PR DESCRIPTION
Testnet v1.1.30.0's delegation SC expects true/false setAutomaticActivation function arguments instead of yes/no.

SC function call succeeds using the new values: https://testnet-explorer.elrond.com/transactions/73027cf4a22ae2000c065b93260a660edb13d763a7186458a5fcdf594d4f3ec8