### PR TITLE
Fix admin max delegation cap card

### DIFF
--- a/react-delegationdashboard/src/components/Overview/Cards/index.tsx
+++ b/react-delegationdashboard/src/components/Overview/Cards/index.tsx
@@ -108,7 +108,7 @@ const Views = () => {
       >
         {location.pathname === '/owner' && <SetPercentageFeeAction />}
       </StatCard>
-      {contractOverview.maxDelegationCap !== '0' && (
+      {isAdmin() && location.pathname === '/owner' ? (
         <StatCard
           title="Delegation Cap"
           value={contractOverview.maxDelegationCap || ''}
@@ -125,9 +125,30 @@ const Views = () => {
             contractOverview.maxDelegationCap
           )}% filled`}
         >
-          {location.pathname === '/owner' && <UpdateDelegationCapAction />}
+          <UpdateDelegationCapAction />
         </StatCard>
+      ) : (
+        contractOverview.maxDelegationCap !== '0' &&
+        contractOverview.maxDelegationCap !== '' && (
+          <StatCard
+            title="Delegation Cap"
+            value={contractOverview.maxDelegationCap || ''}
+            valueUnit={egldLabel}
+            color="green"
+            svg="delegation.svg"
+            percentage={`${getPercentage(
+              denominate({
+                input: totalActiveStake,
+                denomination,
+                decimals,
+                showLastNonZeroDecimal: false,
+              }),
+              contractOverview.maxDelegationCap
+            )}% filled`}
+          ></StatCard>
+        )
       )}
+
       {isAdmin() && location.pathname === '/owner' && (
         <StatCard
           title="Automatic activation"

--- a/react-delegationdashboard/src/config.testnet.ts
+++ b/react-delegationdashboard/src/config.testnet.ts
@@ -30,7 +30,7 @@ export const network: NetworkType = {
   apiAddress: 'https://testnet-api.elrond.com',
   gatewayAddress: 'https://testnet-gateway.elrond.com',
   explorerAddress: 'http://testnet-explorer.elrond.com/',
-  delegationContract: 'erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqlllllskf06ky',
+  delegationContract: 'erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqp0llllswfeycs',
 };
 
 const networkSchema = object({

--- a/react-delegationdashboard/src/config.testnet.ts
+++ b/react-delegationdashboard/src/config.testnet.ts
@@ -30,7 +30,7 @@ export const network: NetworkType = {
   apiAddress: 'https://testnet-api.elrond.com',
   gatewayAddress: 'https://testnet-gateway.elrond.com',
   explorerAddress: 'http://testnet-explorer.elrond.com/',
-  delegationContract: 'erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqp0llllswfeycs',
+  delegationContract: 'erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqlllllskf06ky',
 };
 
 const networkSchema = object({


### PR DESCRIPTION
The max delegation cap card had a bug for the owner dashboard when the delegation cap was infinity the card was not displayed.
I added a new check for '' as the card was displayed for few seconds and disappeared after when the value is infinity which is creating a UI glitch.