### PR TITLE
Fix: DelegateModal only accepts Integer on Safari

### DIFF
--- a/react-delegationdashboard/src/pages/Dashboard/Actions/DelegateAction/DelegateModal.tsx
+++ b/react-delegationdashboard/src/pages/Dashboard/Actions/DelegateAction/DelegateModal.tsx
@@ -102,6 +102,7 @@ const DelegateModal = ({ show, balance, handleClose, handleContinue }: DelegateM
                           id="amount"
                           name="amount"
                           data-testid="amount"
+                          step={'any'}
                           required={true}
                           value={values.amount}
                           autoComplete="off"


### PR DESCRIPTION
OS: MacOS 11.2.3
Browser: Safari 14.0.3
Issue: DelegateModal only accepts integers.