### PR TITLE
Fix Ledger login for next page / Temporal APR fix

### DIFF
--- a/react-delegationdashboard/package.json
+++ b/react-delegationdashboard/package.json
@@ -14,6 +14,7 @@
     "@types/react": "^16.14.3",
     "@types/react-dom": "^16.9.0",
     "@types/react-router-dom": "^5.1.6",
+    "axios": "^0.21.1",
     "bignumber.js": "^9.0.1",
     "bootstrap": "^4.6.0",
     "formik": "^2.2.6",

--- a/react-delegationdashboard/src/components/Layout/index.tsx
+++ b/react-delegationdashboard/src/components/Layout/index.tsx
@@ -23,7 +23,7 @@ const getStakingSCBalance = async (): Promise<string> => {
   if (result.status) {
     return result.data.balance;
   } else {
-    return '0';
+    return 'N/A';
   }
 };
 

--- a/react-delegationdashboard/src/components/Layout/index.tsx
+++ b/react-delegationdashboard/src/components/Layout/index.tsx
@@ -1,7 +1,7 @@
 import { QueryResponse } from '@elrondnetwork/erdjs/out/smartcontracts/query';
 import BigNumber from 'bignumber.js';
 import denominate from 'components/Denominate/formatters';
-import { denomination, decimals } from 'config';
+import { denomination, decimals, auctionContract, network } from 'config';
 import { useContext, useDispatch } from 'context';
 import { emptyAgencyMetaData } from 'context/state';
 import { contractViews } from 'contracts/ContractViews';
@@ -16,6 +16,16 @@ import React from 'react';
 import { calculateAPR } from './APRCalculation';
 import Footer from './Footer';
 import Navbar from './Navbar';
+import axios from 'axios';
+
+const getStakingSCBalance = async (): Promise<string> => {
+  const result = await axios.get(`${network.apiAddress}/accounts/${auctionContract}`);
+  if (result.status) {
+    return result.data.balance;
+  } else {
+    return '0';
+  }
+};
 
 const Layout = ({ children, page }: { children: React.ReactNode; page: string }) => {
   const dispatch = useDispatch();
@@ -73,7 +83,7 @@ const Layout = ({ children, page }: { children: React.ReactNode; page: string })
       getDelegationManagerContractConfig(dapp),
     ])
       .then(
-        ([
+        async ([
           metaData,
           numUsers,
           contractOverview,
@@ -95,9 +105,10 @@ const Layout = ({ children, page }: { children: React.ReactNode; page: string })
             type: 'setMinDelegationAmount',
             minDelegationAmount: delegationManager.returnData[5].asNumber,
           });
+          const contract = getContractOverviewType(contractOverview);
           dispatch({
             type: 'setContractOverview',
-            contractOverview: getContractOverviewType(contractOverview),
+            contractOverview: contract,
           });
           dispatch({
             type: 'setAgencyMetaData',
@@ -122,9 +133,9 @@ const Layout = ({ children, page }: { children: React.ReactNode; page: string })
               networkConfig.ChainID
             ),
           });
-          dispatch({
-            type: 'setAprPercentage',
-            aprPercentage: calculateAPR({
+          const stakingBalance = await getStakingSCBalance(); // Delete it after we migrate to erdjs 4.x
+          const APR = parseFloat(
+            calculateAPR({
               stats: new Stats(networkStats.Epoch),
               networkConfig: new NetworkConfig(
                 networkConfig.TopUpFactor,
@@ -138,11 +149,21 @@ const Layout = ({ children, page }: { children: React.ReactNode; page: string })
                 networkStake.TotalValidators,
                 networkStake.ActiveValidators,
                 networkStake.QueueSize,
-                new BigNumber(networkStake.TotalStaked)
+                new BigNumber(stakingBalance) // Replace with the economics value from erdjs 4.x
               ),
               blsKeys: blsKeys,
               totalActiveStake: activeStake.asBigInt.toFixed(),
-            }),
+            })
+          );
+
+          dispatch({
+            type: 'setAprPercentage',
+            aprPercentage: (
+              APR -
+              APR * ((contract?.serviceFee ? parseFloat(contract.serviceFee) : 15) / 100)
+            )
+              .toFixed(2)
+              .toString(),
           });
         }
       )

--- a/react-delegationdashboard/src/components/Overview/Cards/index.tsx
+++ b/react-delegationdashboard/src/components/Overview/Cards/index.tsx
@@ -101,7 +101,7 @@ const Views = () => {
         valueUnit=""
         color="orange"
         svg="leaf-solid.svg"
-        percentage="Annual percentage rate"
+        percentage="Annual percentage rate incl. service fee"
         tooltipText="This is an approximate APR calculation for this year based on the current epoch"
       />
       <StatCard

--- a/react-delegationdashboard/src/pages/Ledger/AddressTable.tsx
+++ b/react-delegationdashboard/src/pages/Ledger/AddressTable.tsx
@@ -153,7 +153,7 @@ const AddressTable = ({
                       {accounts.map((account, index) => {
                         const props = {
                           account,
-                          index: index + startIndex * 10,
+                          index: index + startIndex * 5,
                           selectedAddress,
                           setSelectedAddress,
                           setSelectedIndex,


### PR DESCRIPTION
We show just 5 addresses per page not 10.
If we select the first wallet from the second page will actually login us with the first wallet from the third page.

Implemented a temporal solution to get the network total staked amount.
Included the service fee in APR.