### PR TITLE
Fix lint error "@typescript-eslint/no-unused-vars"

### DIFF
--- a/react-delegationdashboard/src/config.mainnet.ts
+++ b/react-delegationdashboard/src/config.mainnet.ts
@@ -1,4 +1,4 @@
-import { object, string, boolean, InferType } from 'yup';
+import { object, string, InferType } from 'yup';
 import { DelegationContractType } from './helpers/types';
 
 export const minDust: string = '5000000000000000'; // 0.005 EGLD

--- a/react-delegationdashboard/src/config.testnet.ts
+++ b/react-delegationdashboard/src/config.testnet.ts
@@ -1,4 +1,4 @@
-import { object, string, boolean, InferType } from 'yup';
+import { object, string, InferType } from 'yup';
 import { DelegationContractType } from './helpers/types';
 
 export const minDust: string = '5000000000000000'; // 0.005 EGLD


### PR DESCRIPTION
Our CI fails if it encounters lint errors so this was stopping us from updating

![image](https://user-images.githubusercontent.com/2933351/117941980-f3426300-b34d-11eb-81f3-3e6ae9e5f2da.png)
